### PR TITLE
Readme had wrong link to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export CLOUDFLARE_ACCOUNT_ID=<YOUR_ACCOUNT_ID>   # found at dash.cloudflare.com 
 
 ### 1. Clone the repo
 ```
-git clone https://github.com/descope/sso-redirect-worker.git
+git clone https://github.com/descope/cf-sso-redirect-worker.git
 ```
 
 ### 2. Configure `wrangler.toml`


### PR DESCRIPTION
originally linked to https://github.com/descope/sso-redirect-worker.git, fixed to link to https://github.com/descope/cf-sso-redirect-worker.git