### PR TITLE
feat: per-tenant SSO enable/disable via connection query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,35 @@ This file maps each incoming hostname to its Descope project. Each entry has a t
 |---|---|---|
 | `enabled` | `true` | Enable or disable SSO proxying for this hostname |
 | `logOnly` | `false` | When `true`, logs the intended rewrite but forwards the original request unchanged — useful for validating detection before going live |
+| `tenants` | _(none)_ | Optional per-connection overrides — see below |
 
 SAML requests are rewritten to:
 ```
 https://<newCname>/v1/auth/saml/acs?projectId=<projectId>
 ```
+
+**Per-tenant rollout** — when `tenants` is defined, the worker reads the `connection` query parameter from the incoming ACS URL (e.g. `?connection=sso-conn-a`) and looks it up in the map. The matching entry's `enabled` / `logOnly` values override the top-level defaults for that connection. Connections not present in the map, and requests without a `connection` param, fall back to the top-level `enabled` / `logOnly`.
+
+```json
+"sso": {
+  "enabled": true,
+  "logOnly": true,
+  "tenants": {
+    "sso-conn-a": { "enabled": true,  "logOnly": false },
+    "sso-conn-b": { "enabled": true,  "logOnly": true  },
+    "sso-conn-c": { "enabled": false                   }
+  }
+}
+```
+
+Per-tenant behavior:
+
+| Tenant config | Result |
+|---|---|
+| `enabled: true, logOnly: false` | Rewrite to Descope ACS — connection is live |
+| `enabled: true, logOnly: true` | Log the intended rewrite, forward original request unchanged |
+| `enabled: false` | Forward original request unchanged, no logging |
+| _(not in map)_ | Fall back to top-level `enabled` / `logOnly` |
 
 #### `scim` block
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,14 @@
 import projectConfig from './projectConfig.json';
 
+type SsoTenantEntry = {
+  enabled?: boolean;  // overrides sso.enabled for this connection
+  logOnly?: boolean;  // overrides sso.logOnly for this connection
+};
+
 type SsoConfig = {
   enabled?: boolean;  // defaults to true
   logOnly?: boolean;  // defaults to false — logs the intended rewrite but forwards the original request unchanged
+  tenants?: Record<string, SsoTenantEntry>; // key = connection query param value; overrides top-level per-tenant
 };
 
 // SCIM tenants: '*' = pass all requests through without token replacement
@@ -177,7 +183,23 @@ export default {
     }
 
     // ── SSO ───────────────────────────────────────────────────────────────────
-    const ssoEnabled = config.sso?.enabled ?? true;
+
+    // Resolve effective SSO settings: per-tenant entry (keyed by `connection` query param)
+    // overrides top-level defaults. Falls back to top-level when no tenants map is defined
+    // or when the connection value is not found in the map.
+    const connection = requestUrl.searchParams.get('connection');
+    const tenantEntry = connection ? config.sso?.tenants?.[connection] : undefined;
+    const ssoEnabled = tenantEntry?.enabled ?? (config.sso?.enabled ?? true);
+    const ssoLogOnly = tenantEntry?.logOnly ?? (config.sso?.logOnly ?? false);
+
+    if (connection && config.sso?.tenants) {
+      console.log(
+        'SSO connection:', connection,
+        tenantEntry
+          ? `(per-tenant: enabled=${ssoEnabled}, logOnly=${ssoLogOnly})`
+          : '(not in tenant map, using top-level defaults)',
+      );
+    }
 
     if (!ssoEnabled) {
       console.log('SSO disabled for hostname, forwarding as-is:', hostname);
@@ -220,7 +242,7 @@ export default {
 
     const targetUrl = buildDescopeAcsUrl(request.url, config);
 
-    if (config.sso?.logOnly) {
+    if (ssoLogOnly) {
       console.log('[SSO logOnly] would proxy to:', targetUrl, '— forwarding original request unchanged');
       return passThrough(request);
     }

--- a/src/projectConfig.example.json
+++ b/src/projectConfig.example.json
@@ -4,7 +4,20 @@
 		"projectId": "<your-descope-project-id>",
 		"sso": {
 			"enabled": true,
-			"logOnly": false
+			"logOnly": true,
+			"tenants": {
+				"<connection-name-live>": {
+					"enabled": true,
+					"logOnly": false
+				},
+				"<connection-name-logonly>": {
+					"enabled": true,
+					"logOnly": true
+				},
+				"<connection-name-disabled>": {
+					"enabled": false
+				}
+			}
 		},
 		"scim": {
 			"enabled": false,

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -43,8 +43,22 @@ vi.mock('../src/projectConfig.json', () => ({
     'logonly.example.com': {
       newCname: CNAME,
       projectId: PROJECT_ID,
-      sso: { enabled: true, logOnly: true, tenants: '*' },
+      sso: { enabled: true, logOnly: true },
       scim: { enabled: true, logOnly: true, tenants: '*' },
+    },
+    'sso-tenant-map.example.com': {
+      newCname: CNAME,
+      projectId: PROJECT_ID,
+      sso: {
+        enabled: true,
+        logOnly: true, // top-level default: log-only
+        tenants: {
+          'conn-live':    { enabled: true, logOnly: false },
+          'conn-logonly': { enabled: true, logOnly: true },
+          'conn-off':     { enabled: false },
+        },
+      },
+      scim: { enabled: false },
     },
     'scim-wildcard.example.com': {
       newCname: CNAME,
@@ -285,6 +299,61 @@ describe('SSO Redirect Worker', () => {
         { headers: { Authorization: 'Bearer original-token' } },
       );
       await callWorker(req);
+      const called: Request = mockFetch.mock.calls[0][0];
+      expect(new URL(called.url).hostname).toBe('logonly.example.com');
+    });
+  });
+
+  // ── SSO per-tenant tenant map ───────────────────────────────────────────────
+
+  describe('SSO per-tenant map (connection query param)', () => {
+    // Helper: SAML POST to sso-tenant-map.example.com with an optional ?connection=
+    function tenantSamlPost(connection?: string) {
+      const url = new URL('https://sso-tenant-map.example.com/login/callback');
+      if (connection) url.searchParams.set('connection', connection);
+      return new IncomingRequest(url.toString(), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ SAMLResponse: 'base64encodedresponse' }).toString(),
+      });
+    }
+
+    it('tenant found + live: rewrites to Descope ACS (overrides top-level logOnly)', async () => {
+      await callWorker(tenantSamlPost('conn-live'));
+      const called: Request = mockFetch.mock.calls[0][0];
+      const url = new URL(called.url);
+      expect(url.hostname).toBe(CNAME);
+      expect(url.pathname).toBe('/v1/auth/saml/acs');
+      expect(url.searchParams.get('projectId')).toBe(PROJECT_ID);
+    });
+
+    it('tenant found + logOnly: logs and forwards original request unchanged', async () => {
+      await callWorker(tenantSamlPost('conn-logonly'));
+      const called: Request = mockFetch.mock.calls[0][0];
+      expect(new URL(called.url).hostname).toBe('sso-tenant-map.example.com');
+    });
+
+    it('tenant found + disabled: forwards original request unchanged', async () => {
+      await callWorker(tenantSamlPost('conn-off'));
+      const called: Request = mockFetch.mock.calls[0][0];
+      expect(new URL(called.url).hostname).toBe('sso-tenant-map.example.com');
+    });
+
+    it('tenant not in map: falls back to top-level logOnly, forwards unchanged', async () => {
+      await callWorker(tenantSamlPost('conn-unknown'));
+      const called: Request = mockFetch.mock.calls[0][0];
+      expect(new URL(called.url).hostname).toBe('sso-tenant-map.example.com');
+    });
+
+    it('no connection param: falls back to top-level logOnly, forwards unchanged', async () => {
+      await callWorker(tenantSamlPost()); // no ?connection=
+      const called: Request = mockFetch.mock.calls[0][0];
+      expect(new URL(called.url).hostname).toBe('sso-tenant-map.example.com');
+    });
+
+    it('no tenants block: top-level settings apply as before (existing behavior)', async () => {
+      // logonly.example.com has no tenants map — top-level logOnly: true should forward unchanged
+      await callWorker(samlPost('logonly.example.com', 's/test'));
       const called: Request = mockFetch.mock.calls[0][0];
       expect(new URL(called.url).hostname).toBe('logonly.example.com');
     });


### PR DESCRIPTION
Adds an optional `sso.tenants` map to the per-domain config, keyed by the `connection` query parameter value that Auth0 appends to the ACS URL. This enables a gradual A/B rollout: the top-level `sso.enabled` / `sso.logOnly` acts as the default, and individual connections can override it to go live, stay in log-only, or be disabled entirely.

Resolution priority:
  1. Per-tenant entry found in sso.tenants → use its enabled/logOnly
  2. Connection not in map, or no tenants block → top-level defaults

Full backward compatibility: configs without sso.tenants are unchanged.

- src/index.ts: add SsoTenantEntry type, tenants field on SsoConfig, resolve effective enabled/logOnly from connection param before the existing rewrite/pass-through logic
- src/projectConfig.example.json: show all three tenant states (live, logOnly, disabled)
- test/index.spec.ts: fix stray sso.tenants:'*' on logonly fixture, add sso-tenant-map fixture and 6 new per-tenant resolution tests (27 tests total, all passing)

## Must

- [X] Tests
- [X] Documentation (if applicable)
